### PR TITLE
Fix flaky router test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build package
         run: go build -v .
       - name: Run ci tests
-        run: make all
+        run: make ci
 
   build-and-push-container:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ BIN_DIR := $(GOPATH)/bin
 GOTEST := $(BIN_DIR)/gotest
 PACT_DOCKER_COMPOSE := docker-compose -f pact/docker-compose.yml
 
-.PHONY: all
-all: test integration pact
+.PHONY: ci
+all: test pact
 
 .PHONY: run
 run:
@@ -13,15 +13,15 @@ run:
 build:
 	go build -o todoapi cmd/todoapi/main.go
 
-.PHONY: test
-test: ${GOTEST}
-	@echo "===Unit Tests==="
+.PHONY: only_unit
+only_unit: ${GOTEST}
+	@echo "===Only Unit Tests==="
 	gotest -cover ./... -short
 
-.PHONY: integration
-integration: ${GOTEST}
-	@echo "===Integration Tests==="
-	gotest -cover ./... -run TestGetAllTodos
+.PHONY: test
+test: ${GOTEST}
+	@echo "===All Tests==="
+	gotest -cover ./...
 
 .PHONY: pact
 pact:

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ For more info, checkout the repo.
 There three levels of tests: unit, integration and pact tests. You can run them by:
 
 ```
-make unit
-make integration
+make only_unit # only runs unit tests using the -short flag
+make test # run both unit and integration tests
 make pact
-make all # runs all of the above
+make ci # runs test and pact
 ```
 
 ### Github Actions

--- a/http/router_test.go
+++ b/http/router_test.go
@@ -23,9 +23,7 @@ func TestRouter(t *testing.T) {
 	}
 	go todoHttp.NewRouter(config).ServeOn(3000)
 	err := waitForServer(3000)
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err, "failed to wait for server to start")
 
 	tt := []struct {
 		endpoint string
@@ -37,15 +35,10 @@ func TestRouter(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.endpoint, func(t *testing.T) {
 			res, err := http.Get(fmt.Sprintf("http://localhost:3000%s", tc.endpoint))
-			if err != nil {
-				panic(err)
-			}
+			assert.NoError(t, err, "failed to create request")
 
 			content, err := ioutil.ReadAll(res.Body)
-			if err != nil {
-				panic(err)
-			}
-
+			assert.NoError(t, err, "failed to read response's body")
 			assert.Equal(t, tc.expected, string(content))
 
 		})


### PR DESCRIPTION
 ## Description

Since we are starting a router in a go routine, we should probably wait until it's serving requests before starting the tests.