### PR TITLE
Output JSON logs

### DIFF
--- a/cmd/todoapi/main.go
+++ b/cmd/todoapi/main.go
@@ -6,10 +6,14 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/overkilling/overkill-todo-monolith-api/http"
 	"github.com/overkilling/overkill-todo-monolith-api/postgres"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 )
 
 func main() {
+	log := zerolog.New(os.Stdout).With().
+		Timestamp().
+		Str("service", "api").
+		Logger()
 	dbHost := os.Getenv("DB_HOST")
 
 	db, err := postgres.NewDb(
@@ -36,7 +40,7 @@ func main() {
 		Todos:       http.NewTodosHandler(todosRepository.GetAll),
 	}
 	log.Info().Str("type", "startup").Msg("Starting server on port 3000")
-	err = http.NewRouter(endpoints).ServeOn(3000)
+	err = http.NewRouter(endpoints, log).ServeOn(3000)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lib/pq v1.5.2
 	github.com/pact-foundation/pact-go v1.4.1
 	github.com/rakyll/gotest v0.0.0-20200206190159-3023d5d6366c // indirect
-	github.com/rs/zerolog v1.19.0 // indirect
+	github.com/rs/zerolog v1.19.0
 	github.com/spf13/viper v1.7.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/testcontainers/testcontainers-go v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/lib/pq v1.5.2
 	github.com/pact-foundation/pact-go v1.4.1
 	github.com/rakyll/gotest v0.0.0-20200206190159-3023d5d6366c // indirect
+	github.com/rs/zerolog v1.19.0 // indirect
 	github.com/spf13/viper v1.7.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/testcontainers/testcontainers-go v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -367,7 +367,10 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
+github.com/rs/zerolog v1.15.0 h1:uPRuwkWF4J6fGsJ2R0Gn2jB1EQiav9k3S6CSdygQJXY=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
+github.com/rs/zerolog v1.19.0 h1:hYz4ZVdUgjXTBUmrkrw55j1nHx68LfOKIQk5IYtyScg=
+github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -569,6 +572,7 @@ golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,7 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0 h1:uPRuwkWF4J6fGsJ2R0Gn2jB1EQiav9k3S6CSdygQJXY=

--- a/http/router.go
+++ b/http/router.go
@@ -28,8 +28,10 @@ type Endpoints struct {
 func NewRouter(endpoints Endpoints, log zerolog.Logger) *Router {
 	mux := chi.NewRouter()
 
-	mux.Use(middleware.RequestID)
 	mux.Use(hlog.NewHandler(log))
+	mux.Use(hlog.MethodHandler("http_method"))
+	mux.Use(hlog.URLHandler("url"))
+	mux.Use(hlog.RequestIDHandler("request_id", "Request-ID"))
 	mux.Use(hlog.AccessHandler(accessHandlerLogging))
 	mux.Use(middleware.Recoverer)
 	mux.Use(middleware.Heartbeat("/ping"))
@@ -51,5 +53,8 @@ func (router *Router) Serve(w http.ResponseWriter, r *http.Request) {
 }
 
 func accessHandlerLogging(r *http.Request, status, size int, duration time.Duration) {
-	hlog.FromRequest(r).Info().Msg("something")
+	hlog.FromRequest(r).Info().
+		Int("http_status", status).
+		Int("response_size", size).
+		Send()
 }

--- a/http/router.go
+++ b/http/router.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
+	"github.com/rs/zerolog"
 )
 
 // Router represents a Todo's HTTP router, with the appropriate endpoints
@@ -22,7 +23,8 @@ type Endpoints struct {
 }
 
 // NewRouter provides REST endpoint routing for the Todo API
-func NewRouter(endpoints Endpoints) *Router {
+func NewRouter(endpoints Endpoints, log zerolog.Logger) *Router {
+	log.Info().Msg("something")
 	mux := chi.NewRouter()
 
 	mux.Use(middleware.RequestID)

--- a/http/router_test.go
+++ b/http/router_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
@@ -51,14 +52,12 @@ func TestRouting(t *testing.T) {
 func TestLogging(t *testing.T) {
 	out := &bytes.Buffer{}
 	log := zerolog.New(out).With().Logger()
-	config := todoHttp.Endpoints{
-		Todos: testGetHandler("some-endpoint"),
-	}
-	go todoHttp.NewRouter(config, log).ServeOn(3000)
-	err := waitForServer(3000)
-	assert.NoError(t, err, "failed to wait for server to start")
 
-	http.Get("http://localhost:3000/some-endpoint")
+	req, err := http.NewRequest("GET", "http://localhost:3000/some-endpoint", nil)
+	assert.NoError(t, err, "failed to create request")
+
+	todoHttp.NewRouter(todoHttp.Endpoints{}, log).
+		Serve(httptest.NewRecorder(), req)
 
 	assert.Equal(t, "{\"level\":\"info\",\"message\":\"something\"}\n", string(out.Bytes()))
 }

--- a/pact/provider_test.go
+++ b/pact/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/overkilling/overkill-todo-monolith-api/postgres"
 	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/pact-foundation/pact-go/types"
+	"github.com/rs/zerolog"
 )
 
 func TestPactProvider(t *testing.T) {
@@ -31,6 +32,10 @@ func TestPactProvider(t *testing.T) {
 }
 
 func startProvider() {
+	log := zerolog.New(os.Stdout).With().
+		Timestamp().
+		Str("service", "api").
+		Logger()
 	db, err := postgres.NewDb(
 		postgres.DbName("todo"),
 		postgres.Credentials("postgres", "postgres"),
@@ -52,7 +57,7 @@ func startProvider() {
 		Healthcheck: http.NewHealthcheckHandler(func() bool { return db.Ping() == nil }),
 		Todos:       http.NewTodosHandler(todosRepository.GetAll),
 	}
-	err = http.NewRouter(endpoints).ServeOn(3000)
+	err = http.NewRouter(endpoints, log).ServeOn(3000)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
 ## Description

In order to support log parsing and aggregation, the API needs to log in a structured format, such as JSON.

