### PR TITLE
Log and and update metric when panic is raised

### DIFF
--- a/cmd/todoapi/main.go
+++ b/cmd/todoapi/main.go
@@ -1,29 +1,19 @@
 package main
 
 import (
-	"io"
 	"os"
 
 	_ "github.com/lib/pq"
 	"github.com/overkilling/overkill-todo-monolith-api/http"
 	"github.com/overkilling/overkill-todo-monolith-api/observability/prometheus"
+	"github.com/overkilling/overkill-todo-monolith-api/observability/zerolog"
 	"github.com/overkilling/overkill-todo-monolith-api/postgres"
-	"github.com/rs/zerolog"
 )
 
 func main() {
 	config := loadConfig()
 
-	var logOutput io.Writer
-	logOutput = os.Stdout
-	if config.log.pretty {
-		logOutput = zerolog.ConsoleWriter{Out: os.Stdout}
-	}
-	log := zerolog.New(logOutput).With().
-		Timestamp().
-		Str("service", "api").
-		Logger()
-
+	log := zerolog.NewLogger(os.Stdout, config.log.pretty)
 	db, err := postgres.NewDb(
 		postgres.DbName(config.db.database),
 		postgres.Credentials(config.db.username, config.db.password),

--- a/cmd/todoapi/main.go
+++ b/cmd/todoapi/main.go
@@ -40,7 +40,7 @@ func main() {
 		Todos:       prometheus.InstrumentHandler("todos", http.NewTodosHandler(todosRepository.GetAll)).ServeHTTP,
 	}
 	log.Info().Str("type", "startup").Msg("Starting server on port 3000")
-	err = http.NewRouter(endpoints, log).ServeOn(3000)
+	err = http.NewRouter(endpoints, log, zerolog.NewPanicHandler(), prometheus.NewPanicHandler()).ServeOn(3000)
 	if err != nil {
 		panic(err)
 	}

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -2,13 +2,24 @@ package http
 
 import "net/http"
 
+// RecovererPanicHandler is registered in the Recoverer middleware and
+// is called whenever the middleware recovers from a panic.
+// Useful to log an error message or to report an error metric.
+type RecovererPanicHandler interface {
+	HandlePanic(panicReason interface{})
+}
+
 // Recoverer middleware for capturing panics and delegating to
 // appropriate obsevability handlers. Returns a HTTP 500 status code.
-func Recoverer() func(http.Handler) http.Handler {
+func Recoverer(panicHandlers ...RecovererPanicHandler) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if panicReason := recover(); panicReason != nil {
+					for _, handler := range panicHandlers {
+						handler.HandlePanic(panicReason)
+					}
+
 					w.WriteHeader(http.StatusInternalServerError)
 				}
 			}()

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -1,0 +1,19 @@
+package http
+
+import "net/http"
+
+// Recoverer middleware for capturing panics and delegating to
+// appropriate obsevability handlers. Returns a HTTP 500 status code.
+func Recoverer() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if panicReason := recover(); panicReason != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}()
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -6,25 +6,25 @@ import "net/http"
 // is called whenever the middleware recovers from a panic.
 // Useful to log an error message or to report an error metric.
 type RecovererPanicHandler interface {
-	HandlePanic(panicReason interface{})
+	HandlePanic(req *http.Request, panicReason interface{})
 }
 
 // Recoverer middleware for capturing panics and delegating to
 // appropriate obsevability handlers. Returns a HTTP 500 status code.
 func Recoverer(panicHandlers ...RecovererPanicHandler) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			defer func() {
 				if panicReason := recover(); panicReason != nil {
 					for _, handler := range panicHandlers {
-						handler.HandlePanic(panicReason)
+						handler.HandlePanic(req, panicReason)
 					}
 
 					w.WriteHeader(http.StatusInternalServerError)
 				}
 			}()
 
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(w, req)
 		})
 	}
 }

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -21,7 +21,7 @@ type testPanicHandler struct {
 	handlerCalled bool
 }
 
-func (handler *testPanicHandler) HandlePanic(panicReason interface{}) {
+func (handler *testPanicHandler) HandlePanic(r *realHttp.Request, panicReason interface{}) {
 	handler.handlerCalled = panicReason == "some error"
 }
 

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -1,0 +1,48 @@
+package http_test
+
+import (
+	realHttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/overkilling/overkill-todo-monolith-api/http"
+	"github.com/stretchr/testify/assert"
+)
+
+var noErrorHandler = func(w realHttp.ResponseWriter, r *realHttp.Request) {
+	w.WriteHeader(realHttp.StatusOK)
+}
+
+var panicHandler = func(realHttp.ResponseWriter, *realHttp.Request) {
+	panic("some error")
+}
+
+func TestRecoverer(t *testing.T) {
+	tt := []struct {
+		name         string
+		handler      realHttp.HandlerFunc
+		expectedCode int
+	}{
+		{
+			name:         "no error",
+			handler:      noErrorHandler,
+			expectedCode: realHttp.StatusOK,
+		},
+		{
+			name:         "panic",
+			handler:      panicHandler,
+			expectedCode: realHttp.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			res := httptest.NewRecorder()
+
+			middleware := http.Recoverer()
+			middleware(realHttp.HandlerFunc(tc.handler)).ServeHTTP(res, nil)
+
+			assert.Equal(t, tc.expectedCode, res.Code)
+		})
+	}
+}

--- a/http/router.go
+++ b/http/router.go
@@ -34,7 +34,7 @@ func NewRouter(endpoints Endpoints, log zerolog.Logger) *Router {
 	mux.Use(hlog.URLHandler("url"))
 	mux.Use(hlog.RequestIDHandler("request_id", "Request-ID"))
 	mux.Use(hlog.AccessHandler(accessHandlerLogging))
-	mux.Use(middleware.Recoverer)
+	mux.Use(Recoverer())
 	mux.Use(middleware.Heartbeat("/ping"))
 
 	mux.Get("/metrics", endpoints.Metrics)

--- a/http/router.go
+++ b/http/router.go
@@ -35,7 +35,7 @@ func NewRouter(endpoints Endpoints, log zerolog.Logger) *Router {
 	mux.Use(hlog.URLHandler("url"))
 	mux.Use(hlog.RequestIDHandler("request_id", "Request-ID"))
 	mux.Use(hlog.AccessHandler(accessHandlerLogging))
-	mux.Use(Recoverer(internalZerolog.NewPanicHandler(log)))
+	mux.Use(Recoverer(internalZerolog.NewPanicHandler()))
 	mux.Use(middleware.Heartbeat("/ping"))
 
 	mux.Get("/metrics", endpoints.Metrics)

--- a/http/router.go
+++ b/http/router.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
-	internalZerolog "github.com/overkilling/overkill-todo-monolith-api/observability/zerolog"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 )
@@ -27,7 +26,7 @@ type Endpoints struct {
 }
 
 // NewRouter provides REST endpoint routing for the Todo API
-func NewRouter(endpoints Endpoints, log zerolog.Logger) *Router {
+func NewRouter(endpoints Endpoints, log zerolog.Logger, panicHandlers ...RecovererPanicHandler) *Router {
 	mux := chi.NewRouter()
 
 	mux.Use(hlog.NewHandler(log))
@@ -35,7 +34,7 @@ func NewRouter(endpoints Endpoints, log zerolog.Logger) *Router {
 	mux.Use(hlog.URLHandler("url"))
 	mux.Use(hlog.RequestIDHandler("request_id", "Request-ID"))
 	mux.Use(hlog.AccessHandler(accessHandlerLogging))
-	mux.Use(Recoverer(internalZerolog.NewPanicHandler()))
+	mux.Use(Recoverer(panicHandlers...))
 	mux.Use(middleware.Heartbeat("/ping"))
 
 	mux.Get("/metrics", endpoints.Metrics)

--- a/http/router.go
+++ b/http/router.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
+	internalZerolog "github.com/overkilling/overkill-todo-monolith-api/observability/zerolog"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 )
@@ -34,7 +35,7 @@ func NewRouter(endpoints Endpoints, log zerolog.Logger) *Router {
 	mux.Use(hlog.URLHandler("url"))
 	mux.Use(hlog.RequestIDHandler("request_id", "Request-ID"))
 	mux.Use(hlog.AccessHandler(accessHandlerLogging))
-	mux.Use(Recoverer())
+	mux.Use(Recoverer(internalZerolog.NewPanicHandler(log)))
 	mux.Use(middleware.Heartbeat("/ping"))
 
 	mux.Get("/metrics", endpoints.Metrics)

--- a/observability/prometheus/panic_handler.go
+++ b/observability/prometheus/panic_handler.go
@@ -1,0 +1,32 @@
+package prometheus
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// PanicHandler for counting number of panicked requests
+type PanicHandler struct {
+	panicCounter *prometheus.CounterVec
+}
+
+// HandlePanic increments the panicked requests counter for the
+// given request's path and method
+func (handler *PanicHandler) HandlePanic(req *http.Request, panicReason interface{}) {
+	labels := prometheus.Labels{"path": req.URL.Path, "method": req.Method}
+	handler.panicCounter.With(labels).Inc()
+}
+
+// NewPanicHandler creates a handler for a panicked requests counter.
+func NewPanicHandler() *PanicHandler {
+	panicCounter := promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "panicked_requests_total",
+			Help: "Total number of panicked requests by HTTP path and method",
+		},
+		[]string{"path", "method"},
+	)
+	return &PanicHandler{panicCounter}
+}

--- a/observability/prometheus/panic_handler_test.go
+++ b/observability/prometheus/panic_handler_test.go
@@ -1,0 +1,18 @@
+package prometheus_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/overkilling/overkill-todo-monolith-api/observability/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPanicHandler(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:3000/some-endpoint", nil)
+
+	prometheus.NewPanicHandler().HandlePanic(req, "some reason")
+
+	content := getPrometheusMetrics(t)
+	assert.Contains(t, content, `panicked_requests_total{method="GET",path="/some-endpoint"} 1`)
+}

--- a/observability/zerolog/logger.go
+++ b/observability/zerolog/logger.go
@@ -1,0 +1,19 @@
+package zerolog
+
+import (
+	"io"
+
+	"github.com/rs/zerolog"
+)
+
+// NewLogger creates a new zerolog logger with an optional pretty
+// print format.
+func NewLogger(output io.Writer, prettyPrint bool) zerolog.Logger {
+	if prettyPrint {
+		output = zerolog.ConsoleWriter{Out: output}
+	}
+	return zerolog.New(output).With().
+		Timestamp().
+		Str("service", "api").
+		Logger()
+}

--- a/observability/zerolog/logger.go
+++ b/observability/zerolog/logger.go
@@ -4,11 +4,13 @@ import (
 	"io"
 
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/pkgerrors"
 )
 
 // NewLogger creates a new zerolog logger with an optional pretty
 // print format.
 func NewLogger(output io.Writer, prettyPrint bool) zerolog.Logger {
+	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 	if prettyPrint {
 		output = zerolog.ConsoleWriter{Out: output}
 	}

--- a/observability/zerolog/logger_test.go
+++ b/observability/zerolog/logger_test.go
@@ -1,0 +1,41 @@
+package zerolog_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/overkilling/overkill-todo-monolith-api/observability/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLogger(t *testing.T) {
+	tt := []struct {
+		name               string
+		prettyPrint        bool
+		expectedLogSnippet string
+	}{
+		{
+			name:               "pretty log",
+			prettyPrint:        true,
+			expectedLogSnippet: "\x1b[0m \x1b[32mINF\x1b[0m test log \x1b[36mservice=\x1b[0mapi \x1b[36msome_option=\x1b[0msome_value\n",
+		},
+		{
+			name:               "json log",
+			prettyPrint:        false,
+			expectedLogSnippet: `{"level":"info","service":"api","some_option":"some_value",`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			log := zerolog.NewLogger(out, tc.prettyPrint)
+
+			log.Info().
+				Str("some_option", "some_value").
+				Msg("test log")
+
+			assert.Contains(t, string(out.Bytes()), tc.expectedLogSnippet)
+		})
+	}
+}

--- a/observability/zerolog/panic_handler.go
+++ b/observability/zerolog/panic_handler.go
@@ -1,15 +1,17 @@
 package zerolog
 
-import "github.com/rs/zerolog"
+import (
+	"net/http"
+
+	"github.com/rs/zerolog/hlog"
+)
 
 // PanicHandler for logging recovered panics
-type PanicHandler struct {
-	log zerolog.Logger
-}
+type PanicHandler struct{}
 
 // HandlePanic logs the panic reason as an error
-func (handler *PanicHandler) HandlePanic(panicReason interface{}) {
-	logEvent := handler.log.Error()
+func (handler *PanicHandler) HandlePanic(req *http.Request, panicReason interface{}) {
+	logEvent := hlog.FromRequest(req).Error()
 	if errorReason, ok := panicReason.(error); ok {
 		logEvent.Stack().Err(errorReason)
 	} else {
@@ -19,6 +21,6 @@ func (handler *PanicHandler) HandlePanic(panicReason interface{}) {
 }
 
 // NewPanicHandler creates a handler with a given logger.
-func NewPanicHandler(log zerolog.Logger) *PanicHandler {
-	return &PanicHandler{log}
+func NewPanicHandler() *PanicHandler {
+	return &PanicHandler{}
 }

--- a/observability/zerolog/panic_handler.go
+++ b/observability/zerolog/panic_handler.go
@@ -1,0 +1,24 @@
+package zerolog
+
+import "github.com/rs/zerolog"
+
+// PanicHandler for logging recovered panics
+type PanicHandler struct {
+	log zerolog.Logger
+}
+
+// HandlePanic logs the panic reason as an error
+func (handler *PanicHandler) HandlePanic(panicReason interface{}) {
+	logEvent := handler.log.Error()
+	if errorReason, ok := panicReason.(error); ok {
+		logEvent.Stack().Err(errorReason)
+	} else {
+		logEvent.Interface("error", panicReason)
+	}
+	logEvent.Send()
+}
+
+// NewPanicHandler creates a handler with a given logger.
+func NewPanicHandler(log zerolog.Logger) *PanicHandler {
+	return &PanicHandler{log}
+}

--- a/observability/zerolog/panic_handler_test.go
+++ b/observability/zerolog/panic_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/overkilling/overkill-todo-monolith-api/observability/zerolog"
@@ -33,9 +34,10 @@ func TestPanicHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
 			log := realZerolog.New(out).With().Logger()
-			panicHandler := zerolog.NewPanicHandler(log)
+			req, _ := http.NewRequest("GET", "http://localhost:3000/some-endpoint", nil)
+			req = req.WithContext(log.WithContext(req.Context()))
 
-			panicHandler.HandlePanic(tc.panicReason)
+			zerolog.NewPanicHandler().HandlePanic(req, tc.panicReason)
 
 			expectedLog := fmt.Sprintf(`{
 				"level": "error",

--- a/observability/zerolog/panic_handler_test.go
+++ b/observability/zerolog/panic_handler_test.go
@@ -1,0 +1,47 @@
+package zerolog_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/overkilling/overkill-todo-monolith-api/observability/zerolog"
+	realZerolog "github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPanicHandler(t *testing.T) {
+	tt := []struct {
+		name          string
+		panicReason   interface{}
+		expectedError string
+	}{
+		{
+			name:          "string reason",
+			panicReason:   "some string reason",
+			expectedError: "some string reason",
+		},
+		{
+			name:          "err reason",
+			panicReason:   errors.New("some err reason"),
+			expectedError: "some err reason",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			log := realZerolog.New(out).With().Logger()
+			panicHandler := zerolog.NewPanicHandler(log)
+
+			panicHandler.HandlePanic(tc.panicReason)
+
+			expectedLog := fmt.Sprintf(`{
+				"level": "error",
+				"error": "%s"
+			}`, tc.expectedError)
+			assert.JSONEq(t, expectedLog, string(out.Bytes()))
+		})
+	}
+}


### PR DESCRIPTION
### Description

As part of the observability focus, whenever something goes truly wrong (i.e. a `panic` is raised), we should be able to see the evidence of it in the logs and in some metric.

This PR adds this ability

### How to test

Steps to test :
1. Create or modify an endpoint to raise a panic
2. Start up app and hit the endpoint
3. Verify an error is logged and the metric is updated
