### PR TITLE
Start API through docker in pact tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ test: ${GOTEST}
 .PHONY: pact
 pact:
 	@echo "===Pact==="
-	$(PACT_DOCKER_COMPOSE) up --build --abort-on-container-exit
+	$(PACT_DOCKER_COMPOSE) down --volumes
+	$(PACT_DOCKER_COMPOSE) up -d db
+	$(PACT_DOCKER_COMPOSE) up -d --build api
+	$(PACT_DOCKER_COMPOSE) up --build --abort-on-container-exit pact
 	$(PACT_DOCKER_COMPOSE) down --volumes
 
 $(GOTEST):

--- a/pact/docker-compose.yml
+++ b/pact/docker-compose.yml
@@ -6,8 +6,21 @@ services:
       context: ..
       dockerfile: ./pact/Dockerfile
     environment:
-      DB_HOST: db
+      PROVIDER_URL: http://api:3000 
       PACT_URL: https://raw.githubusercontent.com/overkilling/overkill-todo-infrastructure/master/pacts/spa-api.json
+    depends_on:
+      - api
+    networks:
+      - pact-network
+  api:
+    build:
+      context: ..
+    environment:
+      DB_HOST: db
+    ports:
+      - "3000:3000"
+    expose:
+      - "3000"
     depends_on:
       - db
     networks:


### PR DESCRIPTION
### Description

The previous implementation was a replication of the `cmd/todoapi/main.go` setup. Instead of doing that, it's simpler and more realistic to start the API through Docker.